### PR TITLE
Fix the URL bugs tm

### DIFF
--- a/InnerTube/Models/ChannelLink.cs
+++ b/InnerTube/Models/ChannelLink.cs
@@ -13,12 +13,10 @@ public class ChannelLink
 	{
 		Title = jToken.GetFromJsonPath<string>("title.simpleText")!;
 		Icon = Utils.GetThumbnails(jToken.GetFromJsonPath<JArray>("icon.thumbnails")!).First();
-		// pretty sure the following line will fail at any second
+		// ~~pretty sure the following line will fail at any second~~
+		// no it won't
 		Url = new Uri(
-			HttpUtility.UrlDecode(
-				HttpUtility.ParseQueryString(jToken.GetFromJsonPath<Uri>("navigationEndpoint.urlEndpoint.url")!.Query)
-					.Get("q")
-			)!
+			Utils.UnwrapRedirectUrl(jToken.GetFromJsonPath<string>("navigationEndpoint.urlEndpoint.url")!)
 		);
 	}
 

--- a/InnerTube/Models/EndScreenItem.cs
+++ b/InnerTube/Models/EndScreenItem.cs
@@ -43,9 +43,9 @@ public class EndScreenItem
 				break;
 			case "WEBSITE":
 				Type = EndScreenItemType.Link;
-				Target = HttpUtility.ParseQueryString(
-					json.GetFromJsonPath<string>("endpoint.urlEndpoint.url")?.Split("?")[1] ?? "q="
-				).Get("q")!;
+				Target = Utils.UnwrapRedirectUrl(
+					json.GetFromJsonPath<string>("endpoint.urlEndpoint.url") ?? ""
+				);
 				break;
 			case "PLAYLIST":
 				Type = EndScreenItemType.Playlist;

--- a/InnerTube/Utils.cs
+++ b/InnerTube/Utils.cs
@@ -68,13 +68,8 @@ public static class Utils
 					if (run["navigationEndpoint"]?["urlEndpoint"] is not null)
 					{
 						string url = run["navigationEndpoint"]?["urlEndpoint"]?["url"]?.ToString() ?? "";
-						if (url.StartsWith("https://www.youtube.com/redirect"))
-						{
-							NameValueCollection qsl = HttpUtility.ParseQueryString(url.Split("?")[1]);
-							url = (qsl["url"] ?? qsl["q"])!;
-						}
 
-						currentString = Formatter.FormatUrl(currentString, url);
+						currentString = Formatter.FormatUrl(currentString, UnwrapRedirectUrl(url));
 					}
 					else if (run["navigationEndpoint"]?["commandMetadata"] is not null)
 					{
@@ -93,6 +88,17 @@ public static class Utils
 		}
 
 		return "";
+	}
+
+	public static string UnwrapRedirectUrl(string url)
+	{
+		if (url.StartsWith("https://www.youtube.com/redirect"))
+		{
+			NameValueCollection qsl = HttpUtility.ParseQueryString(url.Split("?")[1]);
+			url = qsl["url"] ?? qsl["q"] ?? url;
+		}
+
+		return url;
 	}
 
 	public static Thumbnail[] GetThumbnails(JArray? thumbnails)
@@ -150,7 +156,7 @@ public static class Utils
 	{
 		if (!TimeSpan.TryParseExact(duration, "%m\\:%s", CultureInfo.InvariantCulture, out TimeSpan timeSpan))
 			if (!TimeSpan.TryParseExact(duration, "%h\\:%m\\:%s",
-				    CultureInfo.InvariantCulture, out timeSpan))
+					CultureInfo.InvariantCulture, out timeSpan))
 				timeSpan = TimeSpan.Zero;
 		return timeSpan;
 	}


### PR DESCRIPTION
The ChannelLink class used to blindly assume the link passed to it is a YouTube redirect link, but alas, it sometimes isn't, for example whenever you link to a different YouTube page.
This PR makes it, and some other places in the code, use a new helper method that unwraps the link if it is a redirect, and doesn't if it isn't.