### PR TITLE
Fix PrimaryLinks being null

### DIFF
--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.0.11</AssemblyVersion>
-        <Version>1.0.11</Version>
+        <AssemblyVersion>1.0.12</AssemblyVersion>
+        <Version>1.0.12</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -15,12 +15,17 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
         <PackageReference Include="Serilog" Version="2.11.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="../README.md" Pack="true" PackagePath=""/>
     </ItemGroup>
 
 </Project>

--- a/InnerTube/Renderers/ChannelAboutFullMetadataRenderer.cs
+++ b/InnerTube/Renderers/ChannelAboutFullMetadataRenderer.cs
@@ -24,7 +24,7 @@ public class ChannelAboutFullMetadataRenderer : IRenderer
 		Description = renderer.GetFromJsonPath<string>("description.simpleText")!;
 		ViewCount = renderer.GetFromJsonPath<string>("viewCountText.simpleText")!;
 		JoinedDate = Utils.ReadText(renderer.GetFromJsonPath<JObject>("joinedDateText")!);
-		PrimaryLinks = renderer.GetFromJsonPath<JArray>("primaryLinks")!.Select(x => new ChannelLink(x));
+		PrimaryLinks = renderer.GetFromJsonPath<JArray>("primaryLinks")?.Select(x => new ChannelLink(x)) ?? Array.Empty<ChannelLink>();
 		Country = renderer.GetFromJsonPath<string>("country.simpleText")!;
 	}
 


### PR DESCRIPTION
# Details
Fix PrimaryLinks being null in ChannelAboutFullMetadataRenderer

# Notes
Also adds a README for NuGet (not tested :3)
