### PR TITLE
Fix various playlist issues (#5, other)

### DIFF
--- a/InnerTube.Tests/BrowseTests.cs
+++ b/InnerTube.Tests/BrowseTests.cs
@@ -71,6 +71,7 @@ public class BrowseTests
 
 	[TestCase("PLv3TTBr1W_9tppikBxAE_G6qjWdBljBHJ", false)]
 	[TestCase("VLPLiDvcIUGEFPv2K8h3SRrpc7FN7Ks0Z_A7", true)]
+	[TestCase("PLWA4fx92eWNstZbKK52BK9Ox-I4KvxdkF", false, Description = "Intentionally empty playlist")]
 	public async Task GetPlaylist(string playlistId, bool includeUnavailable)
 	{
 		InnerTubePlaylist playlist = await _innerTube.GetPlaylistAsync(playlistId, includeUnavailable);

--- a/InnerTube.Tests/SearchTests.cs
+++ b/InnerTube.Tests/SearchTests.cs
@@ -21,6 +21,7 @@ public class SearchTests
 	[TestCase("lofi radio", null, Description = "Used to get live videos")]
 	[TestCase("EvCZ9W2xAMQ", null, Description = "Premiere video")]
 	[TestCase("technoblade", null, Description = "didYouMeanRenderer")]
+	[TestCase("O'zbekcha Kuylar 2020, Vol. 2", null, Description = "epic broken playlist")]
 	public async Task Search(string query, string param)
 	{
 		InnerTubeSearchResults results = await _innerTube.SearchAsync(query, param);

--- a/InnerTube/Models/InnerTubePlaylist.cs
+++ b/InnerTube/Models/InnerTubePlaylist.cs
@@ -47,7 +47,7 @@ public class InnerTubePlaylist
 
 		IRenderer[] renderers = RendererManager.ParseRenderers(browseResponse.GetFromJsonPath<JArray>(
 				"contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer.contents")
-			!).ToArray();
+			).ToArray();
 		Videos = renderers.Where(x => x is PlaylistVideoRenderer).Cast<PlaylistVideoRenderer>();
 		Continuation = ((ContinuationItemRenderer?)renderers.FirstOrDefault(x => x is ContinuationItemRenderer))?.Token;
 		Sidebar = new PlaylistSidebar(browseResponse.GetFromJsonPath<JObject>("sidebar.playlistSidebarRenderer")!);

--- a/InnerTube/Models/InnerTubePlaylist.cs
+++ b/InnerTube/Models/InnerTubePlaylist.cs
@@ -48,7 +48,7 @@ public class InnerTubePlaylist
 		IRenderer[] renderers = RendererManager.ParseRenderers(browseResponse.GetFromJsonPath<JArray>(
 				"contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer.contents")
 			).ToArray();
-		Videos = renderers.Where(x => x is PlaylistVideoRenderer).Cast<PlaylistVideoRenderer>();
+		Videos = renderers.OfType<PlaylistVideoRenderer>();
 		Continuation = ((ContinuationItemRenderer?)renderers.FirstOrDefault(x => x is ContinuationItemRenderer))?.Token;
 		Sidebar = new PlaylistSidebar(browseResponse.GetFromJsonPath<JObject>("sidebar.playlistSidebarRenderer")!);
 	}

--- a/InnerTube/RendererManager.cs
+++ b/InnerTube/RendererManager.cs
@@ -34,8 +34,11 @@ public static class RendererManager
 		return new UnknownRenderer(renderer);
 	}
 	
-	public static IEnumerable<IRenderer> ParseRenderers(JArray rendererArray)
+	public static IEnumerable<IRenderer> ParseRenderers(JArray? rendererArray)
 	{
+		if (rendererArray is null)
+			return Array.Empty<IRenderer>();
+
 		return from renderer
 				in rendererArray
 			let type = renderer.First?.Path.Split(".").Last()!

--- a/InnerTube/Renderers/PlaylistRenderer.cs
+++ b/InnerTube/Renderers/PlaylistRenderer.cs
@@ -23,8 +23,11 @@ public class PlaylistRenderer : IRenderer
 
 		Thumbnails =
 			Utils.GetThumbnails(
-				renderer.GetFromJsonPath<JArray>(
-					"thumbnailRenderer.playlistVideoThumbnailRenderer.thumbnail.thumbnails")!);
+				(renderer["thumbnailRenderer"] as JObject)
+					?.Properties()
+					.FirstOrDefault()
+					?.Value
+					?.GetFromJsonPath<JArray>("thumbnail.thumbnails"));
 		VideoThumbnails = new Dictionary<string, IEnumerable<Thumbnail>>();
 		foreach (JArray thumbnails in renderer["thumbnails"]!.ToObject<JArray>()!.Select(x =>
 			         x["thumbnails"]!.ToObject<JArray>()!))

--- a/InnerTube/Renderers/PlaylistRenderer.cs
+++ b/InnerTube/Renderers/PlaylistRenderer.cs
@@ -44,7 +44,7 @@ public class PlaylistRenderer : IRenderer
 				?.Select(x => new Badge(x["metadataBadgeRenderer"]!)) ?? Array.Empty<Badge>()
 		};
 
-		Videos = RendererManager.ParseRenderers(renderer["videos"]!.ToObject<JArray>()!).Cast<ChildVideoRenderer>();
+		Videos = RendererManager.ParseRenderers(renderer["videos"]?.ToObject<JArray>()).Cast<ChildVideoRenderer>();
 	}
 
 	public override string ToString()


### PR DESCRIPTION
Playlists can have 0 videos in them. As such, their content renders are null, which crashes InnerTube, as it expects the array to be non-null. Changing ParseRenderers to accept nullable arrays (and making it return empty collections back for them) fixes this.
Test case included.

Also fixes #5 by not specifying the thumbnail renderer type

Example:
LightTube: https://tube.kuylar.dev/playlist?list=PLWA4fx92eWNstZbKK52BK9Ox-I4KvxdkF
YouTube: https://youtube.com/playlist?list=PLWA4fx92eWNstZbKK52BK9Ox-I4KvxdkF

LightTube: https://tube.kuylar.dev/results?search_query=O%27zbekcha+Kuylar+2020%2C+Vol.+2
