### PR TITLE
Implement multiple audio tracks

### DIFF
--- a/InnerTube.Tests/PlayerTests.cs
+++ b/InnerTube.Tests/PlayerTests.cs
@@ -18,6 +18,7 @@ public class PlayerTests
 	[TestCase("J6Ga4wciA2k", true, false, Description = "Load a video with the endscreen & info cards")]
 	[TestCase("jfKfPfyJRdk", true, false, Description = "Load a livestream")]
 	[TestCase("9gIXoaB-Jik", true, false, Description = "Video with WEBSITE endscreen item")]
+	[TestCase("4ZX9T0kWb4Y", true, false, Description = "Video with multiple audio tracks")]
 	public async Task GetPlayer(string videoId, bool contentCheckOk, bool includeHls)
 	{
 		InnerTubePlayer player = await _innerTube.GetPlayerAsync(videoId, contentCheckOk, includeHls);
@@ -80,7 +81,8 @@ public class PlayerTests
 				.AppendLine("   Quality: " + f.Quality)
 				.AppendLine("   AudioQuality: " + f.AudioQuality)
 				.AppendLine("   AudioSampleRate: " + f.AudioSampleRate)
-				.AppendLine("   AudioChannels: " + f.AudioChannels);
+				.AppendLine("   AudioChannels: " + f.AudioChannels)
+				.AppendLine("   AudioTrack: " + (f.AudioTrack?.ToString() ?? "<no audio track>"));
 		}
 
 		sb.AppendLine("== ADAPTIVE FORMATS");
@@ -100,7 +102,8 @@ public class PlayerTests
 				.AppendLine("   Quality: " + f.Quality)
 				.AppendLine("   AudioQuality: " + f.AudioQuality)
 				.AppendLine("   AudioSampleRate: " + f.AudioSampleRate)
-				.AppendLine("   AudioChannels: " + f.AudioChannels);
+				.AppendLine("   AudioChannels: " + f.AudioChannels)
+				.AppendLine("   AudioTrack: " + (f.AudioTrack?.ToString() ?? "<no audio track>"));
 		}
 
 		sb.AppendLine("== OTHER")

--- a/InnerTube/Models/Format.cs
+++ b/InnerTube/Models/Format.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace InnerTube;
 
@@ -19,6 +20,7 @@ public class Format
 	public string? AudioQuality { get; }
 	public int? AudioSampleRate { get; }
 	public int? AudioChannels { get; }
+	public AudioTrack? AudioTrack { get; }
 
 	public Format(JToken jToken)
 	{
@@ -37,7 +39,17 @@ public class Format
 		AudioQuality = jToken["audioQuality"]?.ToString();
 		AudioSampleRate = int.Parse(jToken["audioSampleRate"]?.ToString() ?? "0");
 		AudioChannels = jToken["audioChannels"]?.ToObject<int>();
+		AudioTrack = jToken["audioTrack"]?.ToObject<AudioTrack>();
 	}
+}
+
+public class AudioTrack
+{
+	[JsonProperty("displayName")] public string DisplayName { get; set; }
+	[JsonProperty("id")] public string Id { get; set; }
+	[JsonProperty("audioIsDefault")] public bool AudioIsDefault { get; set; }
+
+	public override string ToString() => $"[{Id}] {DisplayName}{(AudioIsDefault ?" (default)" : "")}";
 }
 
 public class DashRange


### PR DESCRIPTION
# Details
YouTube added multiple audio tracks (can be used for dubbing/audio descriptions). This PR implements them in the Format object.

# Changes proposed
* Add AudioTrack field in Format which includes the following:
  * Audio track ID
  * Audio track label
  * If the audio track is the default one

# Notes
This *kind of* breaks the LightTube media proxy
Also, here is a video that has multiple audio tracks https://youtu.be/4ZX9T0kWb4Y
