### PR TITLE
More channel tabs

### DIFF
--- a/InnerTube.Tests/BrowseTests.cs
+++ b/InnerTube.Tests/BrowseTests.cs
@@ -25,6 +25,8 @@ public class BrowseTests
 	[TestCase("UCFAiFyGs6oDiF1Nf-rRJpZA", (int)ChannelTabs.Search, "skyblock")]
 	[TestCase("@kuylardev", (int)ChannelTabs.Home, null)]
 	[TestCase("@Highly_Original", (int)ChannelTabs.About, null)]
+	[TestCase("@LinusTechTips", (int)ChannelTabs.Podcasts, null)]
+	[TestCase("@daftpunk", (int)ChannelTabs.Releases, null)]
 	public async Task GetChannel(string channelId, ChannelTabs tab, string query)
 	{
 		try

--- a/InnerTube/Enums.cs
+++ b/InnerTube/Enums.cs
@@ -72,6 +72,16 @@ public enum ChannelTabs
 	/// </summary>
 	Playlists,
 	/// <summary>
+	/// Podcasts tab.
+	/// Not available on all channels.
+	/// </summary>
+	Podcasts,
+	/// <summary>
+	/// Releases tab.
+	/// Only available in music channels [citation needed]
+	/// </summary>
+	Releases,
+	/// <summary>
 	/// Community tab.
 	/// </summary>
 	Community,

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.0.15</AssemblyVersion>
-        <Version>1.0.15</Version>
+        <AssemblyVersion>1.0.16</AssemblyVersion>
+        <Version>1.0.16</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/Renderers/PlaylistRenderer.cs
+++ b/InnerTube/Renderers/PlaylistRenderer.cs
@@ -34,7 +34,7 @@ public class PlaylistRenderer : IRenderer
 		{
 			string videoId = thumbnails.First()["url"]!.ToString().Split("/vi/")[1].Split("/")[0];
 			Thumbnail[] thumbs = Utils.GetThumbnails(thumbnails);
-			VideoThumbnails.Add(videoId, thumbs);
+			VideoThumbnails.TryAdd(videoId, thumbs);
 		}
 
 		Channel = new Channel

--- a/InnerTube/Utils.cs
+++ b/InnerTube/Utils.cs
@@ -98,6 +98,9 @@ public static class Utils
 			url = qsl["url"] ?? qsl["q"] ?? url;
 		}
 
+		if (!url.StartsWith("http"))
+			url = "https://" + url;
+
 		return url;
 	}
 
@@ -169,6 +172,8 @@ public static class Utils
 			ChannelTabs.Shorts => "EgZzaG9ydHPyBgUKA5oBAA%3D%3D",
 			ChannelTabs.Live => "EgdzdHJlYW1z8gYECgJ6AA%3D%3D",
 			ChannelTabs.Playlists => "EglwbGF5bGlzdHM%3D",
+			ChannelTabs.Podcasts => "Eghwb2RjYXN0c_IGBQoDugEA",
+			ChannelTabs.Releases => "EghyZWxlYXNlc_IGBQoDsgEA",
 			ChannelTabs.Community => "Egljb21tdW5pdHk%3D",
 			ChannelTabs.Channels => "EghjaGFubmVscw%3D%3D",
 			ChannelTabs.About => "EgVhYm91dA%3D%3D",
@@ -177,6 +182,7 @@ public static class Utils
 		};
 
 	public static ChannelTabs GetTabFromParams(string param) =>
+		// this method is starting to look slightly stupid with every new tab youtube adds
 		string.Join("", param.Take(9)) switch
 		{
 			"EghmZWF0d" => ChannelTabs.Home,
@@ -184,6 +190,8 @@ public static class Utils
 			"EgZzaG9yd" => ChannelTabs.Shorts,
 			"EgdzdHJlY" => ChannelTabs.Live,
 			"EglwbGF5b" => ChannelTabs.Playlists,
+			"Eghwb2RjY" => ChannelTabs.Podcasts,
+			"EghyZWxlY" => ChannelTabs.Releases,
 			"Egljb21td" => ChannelTabs.Community,
 			"EghjaGFub" => ChannelTabs.Channels,
 			"EgVhYm91d" => ChannelTabs.About,


### PR DESCRIPTION
# Details
Adds more channel tabs found in some channels.

# Changes proposed
* Adds more channel tabs
  - "Releases" tab, found in https://www.youtube.com/@daftpunk
  - "Podcasts" tab, found in https://www.youtube.com/@LinusTechTips
* Fixes Utils.UnwrapRedirectUri returning Uris with no protocols
* makes playlistrenderer not explod