### PR TITLE
Fix "The format of value ' ' is invalid." on authenticated requests

### DIFF
--- a/InnerTube/InnerTube.cs
+++ b/InnerTube/InnerTube.cs
@@ -49,7 +49,8 @@ public class InnerTube
 
 		if (authorized && Authorization is not null)
 		{
-			hrm.Headers.Add("Cookie", Authorization.GenerateCookieHeader());
+			if (Authorization.Type == AuthorizationType.SAPISID)
+				hrm.Headers.Add("Cookie", Authorization.GenerateCookieHeader());
 			hrm.Headers.Add("Authorization", Authorization.GenerateAuthHeader());
 		}
 

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.0.22</AssemblyVersion>
-        <Version>1.0.22</Version>
+        <AssemblyVersion>1.0.23</AssemblyVersion>
+        <Version>1.0.23</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>


### PR DESCRIPTION
# Related issues/PRs
Fixes kuylar/lighttube#65

# Changes proposed
* Fix the empty header on authenticated requests