### PR TITLE
Implement AdSlotRenderer

### DIFF
--- a/InnerTube.Tests/SearchTests.cs
+++ b/InnerTube.Tests/SearchTests.cs
@@ -25,6 +25,7 @@ public class SearchTests
 	[TestCase("O'zbekcha Kuylar 2020, Vol. 2", null, Description = "epic broken playlist")]
 	[TestCase("cars 2", "movie", Description = "movieRenderer")]
 	[TestCase("", "exact", Description = "backgroundPromoRenderer")]
+	[TestCase("vpn", null, Description = "adSlotRenderer")]
 	public async Task Search(string query, string paramArgs)
 	{
 		SearchParams? param = paramArgs switch

--- a/InnerTube/RendererManager.cs
+++ b/InnerTube/RendererManager.cs
@@ -33,7 +33,7 @@ public static class RendererManager
 
 			if (Renderers.TryGetValue(type, out Type? rendererType))
 				return (IRenderer)Activator.CreateInstance(rendererType, renderer)!;
-			return new UnknownRenderer(renderer);
+			return new UnknownRenderer(renderer, type);
 		}
 		catch (Exception e)
 		{

--- a/InnerTube/Renderers/AdSlotRenderer.cs
+++ b/InnerTube/Renderers/AdSlotRenderer.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace InnerTube.Renderers;
+
+public class AdSlotRenderer : IRenderer
+{
+	public string Type => "adSlotRenderer";
+
+	public IRenderer? Content { get; }
+
+	public AdSlotRenderer(JToken renderer)
+	{
+		JObject? obj = renderer
+			.GetFromJsonPath<JObject>("fulfillmentContent.fulfilledLayout.inFeedAdLayoutRenderer.renderingContent")
+			?.First?.ToObject<JObject>();
+		Content = obj != null ? RendererManager.ParseRenderer(obj.First!, obj.Path.Split(".").Last())! : null;
+	}
+
+	public override string ToString() =>
+		new StringBuilder()
+			.AppendLine($"[{Type}]")
+			.AppendLine(string.Join('\n',
+				Content?.ToString()?.Split('\n').Select(x => $"\t{x}") ?? Array.Empty<string>()))
+			.ToString();
+}

--- a/InnerTube/Renderers/AdSlotRenderer.cs
+++ b/InnerTube/Renderers/AdSlotRenderer.cs
@@ -11,10 +11,10 @@ public class AdSlotRenderer : IRenderer
 
 	public AdSlotRenderer(JToken renderer)
 	{
-		JObject? obj = renderer
+		JProperty? obj = renderer
 			.GetFromJsonPath<JObject>("fulfillmentContent.fulfilledLayout.inFeedAdLayoutRenderer.renderingContent")
-			?.First?.ToObject<JObject>();
-		Content = obj != null ? RendererManager.ParseRenderer(obj.First!, obj.Path.Split(".").Last())! : null;
+			?.First?.ToObject<JProperty>();
+		Content = obj != null ? RendererManager.ParseRenderer(obj.Value.ToObject<JObject>(), obj.Name)! : null;
 	}
 
 	public override string ToString() =>

--- a/InnerTube/Renderers/UnknownRenderer.cs
+++ b/InnerTube/Renderers/UnknownRenderer.cs
@@ -14,6 +14,12 @@ public class UnknownRenderer : IRenderer
 		Type = renderer.Path.Split(".").Last();
 	}
 
+	public UnknownRenderer(JToken renderer, string type)
+	{
+		Json = renderer;
+		Type = type;
+	}
+
 	public override string ToString()
 	{
 		return $"Unknown renderer of type: {Type}. JSON:\n\t{Json.ToString(Formatting.None)}";


### PR DESCRIPTION
# Details
:warning: SearchAsync sometimes returns a single AdSlotRenderer, I'm not sure how to fix this. Looks like sending a few more requests fixes the issue

# Related issues/PRs
Closes #37 

# Changes proposed
* Implement AdSlotRenderer
* Implement tests for AdSlotRenderer