### PR TITLE
Keywords can now be null

### DIFF
--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.0.26</AssemblyVersion>
-        <Version>1.0.26</Version>
+        <AssemblyVersion>1.0.27</AssemblyVersion>
+        <Version>1.0.27</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/Models/InnerTubePlayer.cs
+++ b/InnerTube/Models/InnerTubePlayer.cs
@@ -26,7 +26,7 @@ public class InnerTubePlayer
 				Id = metadataResponse.GetFromJsonPath<string>("videoDetails.channelId")!,
 				Title = metadataResponse.GetFromJsonPath<string>("videoDetails.author")!
 			},
-			Keywords = metadataResponse.GetFromJsonPath<string[]>("videoDetails.keywords")!,
+			Keywords = metadataResponse.GetFromJsonPath<string[]>("videoDetails.keywords") ?? Array.Empty<string>(),
 			ShortDescription = metadataResponse.GetFromJsonPath<string>("videoDetails.shortDescription")!,
 			Category = metadataResponse.GetFromJsonPath<string>("videoDetails.category")!,
 			UploadDate = DateTimeOffset.Parse(metadataResponse.GetFromJsonPath<string>("microformat.playerMicroformatRenderer.uploadDate")!, CultureInfo.InvariantCulture),


### PR DESCRIPTION
# Details
YouTube started not sending `videoDetails.keywords` in some edge cases. This PR makes it so we fall back to an empty array for keywords.

# Changes proposed
* Fix nullable keywords