### PR TITLE
Fix a nullreference in the EndScreenItem ctor

### DIFF
--- a/InnerTube.Tests/PlayerTests.cs
+++ b/InnerTube.Tests/PlayerTests.cs
@@ -19,6 +19,7 @@ public class PlayerTests
 	[TestCase("jfKfPfyJRdk", true, false, Description = "Load a livestream")]
 	[TestCase("9gIXoaB-Jik", true, false, Description = "Video with WEBSITE endscreen item")]
 	[TestCase("4ZX9T0kWb4Y", true, false, Description = "Video with multiple audio tracks")]
+	[TestCase("-UBaW1OIgTo", true, false, Description = "EndScreenItem ctor")]
 	public async Task GetPlayer(string videoId, bool contentCheckOk, bool includeHls)
 	{
 		InnerTubePlayer player = await _innerTube.GetPlayerAsync(videoId, contentCheckOk, includeHls);

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
-        <Version>1.1.0</Version>
+        <AssemblyVersion>1.1.1</AssemblyVersion>
+        <Version>1.1.1</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/Models/EndScreenItem.cs
+++ b/InnerTube/Models/EndScreenItem.cs
@@ -22,7 +22,7 @@ public class EndScreenItem
 	{
 		Title = Utils.ReadText(json["title"]!.ToObject<JObject>()!);
 		Image = Utils.GetThumbnails(json.GetFromJsonPath<JArray>("image.thumbnails")!);
-		Metadata = Utils.ReadText(json["metadata"]!.ToObject<JObject>()!);
+		Metadata = Utils.ReadText(json["metadata"]?.ToObject<JObject>());
 		Style = json["style"]!.ToString();
 		StartMs = long.Parse(json["startMs"]!.ToString());
 		EndMs = long.Parse(json["endMs"]!.ToString());


### PR DESCRIPTION
# Details
Sometimes, the metadata text can be null...for some reason

# Related issues/PRs
Fixes #43 

# Changes proposed
* Fix a nullref in EndScreenItem ctor